### PR TITLE
Generating Version Catalog TOML file for dependencies and versions

### DIFF
--- a/src/commonMain/kotlin/wizard/Dependencies.kt
+++ b/src/commonMain/kotlin/wizard/Dependencies.kt
@@ -7,6 +7,12 @@ val AndroidxAppcompat = Dependency(
     group = "androidx.appcompat",
     id = "appcompat",
     version = "1.6.1",
+    versionCatalog = VersionCatalog(
+        versionRefName = "androidx-appcompat",
+        libraryName = "androidx-appcompat",
+        libraryAccessor = "androidx.appcompat",
+    ),
+    applyToModule = true,
     platforms = setOf(ComposePlatform.Android)
 )
 
@@ -17,6 +23,12 @@ val AndroidxActivityCompose = Dependency(
     group = "androidx.activity",
     id = "activity-compose",
     version = "1.7.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "androidx-activityCompose",
+        libraryName = "androidx-activityCompose",
+        libraryAccessor = "androidx.activityCompose",
+    ),
+    applyToModule = true,
     platforms = setOf(ComposePlatform.Android)
 )
 
@@ -27,6 +39,12 @@ val ComposeUiTooling = Dependency(
     group = "androidx.compose.ui",
     id = "ui-tooling",
     version = "1.4.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "compose-uitooling",
+        libraryName = "compose-uitooling",
+        libraryAccessor = "compose.uitooling",
+    ),
+    applyToModule = true,
     platforms = setOf(ComposePlatform.Android)
 )
 
@@ -37,6 +55,12 @@ val LibresPlugin = Dependency(
     group = "io.github.skeptick.libres",
     id = "gradle-plugin",
     version = "1.1.7",
+    versionCatalog = VersionCatalog(
+        versionRefName = "libres",
+        libraryName = "libres",
+        libraryAccessor = "libres",
+    ),
+    applyToModule = true,
     platforms = emptySet()
 )
 
@@ -52,6 +76,12 @@ val Voyager = Dependency(
     group = "cafe.adriel.voyager",
     id = "voyager-navigator",
     version = "1.0.0-rc04",
+    versionCatalog = VersionCatalog(
+        versionRefName = "voyager",
+        libraryName = "voyager-navigator",
+        libraryAccessor = "voyager.navigator",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
@@ -62,6 +92,12 @@ val ImageLoader = Dependency(
     group = "io.github.qdsfdhvh",
     id = "image-loader",
     version = "1.2.10",
+    versionCatalog = VersionCatalog(
+        versionRefName = "composeImageLoader",
+        libraryName = "composeImageLoader",
+        libraryAccessor = "composeImageLoader",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
@@ -72,6 +108,12 @@ val Napier = Dependency(
     group = "io.github.aakira",
     id = "napier",
     version = "2.6.1",
+    versionCatalog = VersionCatalog(
+        versionRefName = "napier",
+        libraryName = "napier",
+        libraryAccessor = "napier",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
@@ -82,6 +124,12 @@ val KotlinxDateTime = Dependency(
     group = "org.jetbrains.kotlinx",
     id = "kotlinx-datetime",
     version = "0.4.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "kotlinx-datetime",
+        libraryName = "kotlinx-datetime",
+        libraryAccessor = "kotlinx.datetime",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
@@ -92,6 +140,12 @@ val MultiplatformSettings = Dependency(
     group = "com.russhwolf",
     id = "multiplatform-settings",
     version = "1.0.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "multiplatformSettings",
+        libraryName = "multiplatformSettings",
+        libraryAccessor = "multiplatformSettings",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
@@ -102,6 +156,12 @@ val Koin = Dependency(
     group = "io.insert-koin",
     id = "koin-core",
     version = "3.4.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "koin",
+        libraryName = "koin-core",
+        libraryAccessor = "koin.core",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
@@ -112,6 +172,12 @@ val KStore = Dependency(
     group = "io.github.xxfast",
     id = "kstore",
     version = "0.5.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "kstore",
+        libraryName = "kstore",
+        libraryAccessor = "kstore",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
@@ -122,21 +188,39 @@ val KtorCore = Dependency(
     group = "io.ktor",
     id = "ktor-client-core",
     version = "2.2.4",
+    versionCatalog = VersionCatalog(
+        versionRefName = "ktor",
+        libraryName = "ktor-core",
+        libraryAccessor = "ktor.core",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
 val KtorClientDarwin = KtorCore.copy(
     id = "ktor-client-darwin",
+    versionCatalog = KtorCore.versionCatalog.copy(
+        libraryName = "ktor-client-darwin",
+        libraryAccessor = "ktor.client.darwin",
+    ),
     platforms = setOf(ComposePlatform.Ios)
 )
 
 val KtorClientOkhttp = KtorCore.copy(
     id = "ktor-client-okhttp",
+    versionCatalog = KtorCore.versionCatalog.copy(
+        libraryName = "ktor-client-okhttp",
+        libraryAccessor = "ktor.client.okhttp",
+    ),
     platforms = setOf(ComposePlatform.Android, ComposePlatform.Desktop)
 )
 
 val KtorClientJs = KtorCore.copy(
     id = "ktor-client-js",
+    versionCatalog = KtorCore.versionCatalog.copy(
+        libraryName = "ktor-client-js",
+        libraryAccessor = "ktor.client.js",
+    ),
     platforms = setOf(ComposePlatform.Browser)
 )
 
@@ -147,11 +231,21 @@ val KotlinxCoroutinesCore = Dependency(
     group = "org.jetbrains.kotlinx",
     id = "kotlinx-coroutines-core",
     version = "1.6.4",
+    versionCatalog = VersionCatalog(
+        versionRefName = "kotlinx-coroutines",
+        libraryName = "kotlinx-coroutines-core",
+        libraryAccessor = "kotlinx.coroutines.core",
+    ),
+    applyToModule = true,
     platforms = AllPlatforms
 )
 
 val KotlinxCoroutinesAndroid = KotlinxCoroutinesCore.copy(
     id = "kotlinx-coroutines-android",
+    versionCatalog = KotlinxCoroutinesCore.versionCatalog.copy(
+        libraryName = "kotlinx-coroutines-android",
+        libraryAccessor = "kotlinx.coroutines.android",
+    ),
     platforms = setOf(ComposePlatform.Android)
 )
 
@@ -162,6 +256,12 @@ val KotlinxSerializationPlugin = Dependency(
     group = "org.jetbrains.kotlin",
     id = "kotlin-serialization",
     version = "[the same as Kotlin version!]",
+    versionCatalog = VersionCatalog(
+        versionRefName = "",
+        libraryName = "",
+        libraryAccessor = "",
+    ),
+    applyToModule = true,
     platforms = emptySet()
 )
 
@@ -170,6 +270,11 @@ val KotlinxSerializationJson = KotlinxSerializationPlugin.copy(
     group = "org.jetbrains.kotlinx",
     id = "kotlinx-serialization-json",
     version = "1.5.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "kotlinx-serialization",
+        libraryName = "kotlinx-serialization-json",
+        libraryAccessor = "kotlinx.serialization.json",
+    ),
     platforms = AllPlatforms
 )
 
@@ -180,26 +285,48 @@ val SQLDelightPlugin = Dependency(
     group = "app.cash.sqldelight",
     id = "gradle-plugin",
     version = "2.0.0-alpha05",
+    versionCatalog = VersionCatalog(
+        versionRefName = "sqlDelight",
+        libraryName = "sqlDelight",
+        libraryAccessor = "sqlDelight",
+    ),
+    applyToModule = true,
     platforms = emptySet()
 )
 
 val SQLDelightDriverJvm = SQLDelightPlugin.copy(
     id = "sqlite-driver",
+    versionCatalog = SQLDelightPlugin.versionCatalog.copy(
+        libraryName = "sqlDelight-driver-sqlite",
+        libraryAccessor = "sqlDelight.driver.sqlite",
+    ),
     platforms = setOf(ComposePlatform.Desktop)
 )
 
 val SQLDelightDriverAndroid = SQLDelightPlugin.copy(
     id = "android-driver",
+    versionCatalog = SQLDelightPlugin.versionCatalog.copy(
+        libraryName = "sqlDelight-driver-android",
+        libraryAccessor = "sqlDelight.driver.android",
+    ),
     platforms = setOf(ComposePlatform.Android)
 )
 
 val SQLDelightDriverNative = SQLDelightPlugin.copy(
     id = "native-driver",
+    versionCatalog = SQLDelightPlugin.versionCatalog.copy(
+        libraryName = "sqlDelight-driver-native",
+        libraryAccessor = "sqlDelight.driver.native",
+    ),
     platforms = setOf(ComposePlatform.Ios)
 )
 
 val SQLDelightDriverJs = SQLDelightPlugin.copy(
     id = "sqljs-driver",
+    versionCatalog = SQLDelightPlugin.versionCatalog.copy(
+        libraryName = "sqlDelight-driver-sqljs",
+        libraryAccessor = "sqlDelight.driver.sqljs",
+    ),
     platforms = setOf(ComposePlatform.Browser)
 )
 
@@ -210,11 +337,21 @@ val ApolloPlugin = Dependency(
     group = "com.apollographql.apollo3",
     id = "apollo-gradle-plugin",
     version = "3.7.5",
+    versionCatalog = VersionCatalog(
+        versionRefName = "apollo",
+        libraryName = "apollo",
+        libraryAccessor = "apollo",
+    ),
+    applyToModule = true,
     platforms = emptySet()
 )
 
 val ApolloRuntime = ApolloPlugin.copy(
     id = "apollo-runtime",
+    versionCatalog = ApolloPlugin.versionCatalog.copy(
+        libraryName = "apollo-runtime",
+        libraryAccessor = "apollo.runtime",
+    ),
     platforms = AllPlatforms
 )
 
@@ -225,5 +362,11 @@ val BuildConfigPlugin = Dependency(
     group = "com.github.gmazzo.buildconfig",
     id = "gradle-plugin",
     version = "3.1.0",
+    versionCatalog = VersionCatalog(
+        versionRefName = "buildConfig",
+        libraryName = "buildConfig",
+        libraryAccessor = "buildConfig",
+    ),
+    applyToModule = true,
     platforms = emptySet()
 )

--- a/src/commonMain/kotlin/wizard/Dependencies.kt
+++ b/src/commonMain/kotlin/wizard/Dependencies.kt
@@ -10,7 +10,6 @@ val AndroidxAppcompat = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "androidx-appcompat",
         libraryName = "androidx-appcompat",
-        libraryAccessor = "androidx.appcompat",
     ),
     applyToModule = true,
     platforms = setOf(ComposePlatform.Android)
@@ -26,7 +25,6 @@ val AndroidxActivityCompose = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "androidx-activityCompose",
         libraryName = "androidx-activityCompose",
-        libraryAccessor = "androidx.activityCompose",
     ),
     applyToModule = true,
     platforms = setOf(ComposePlatform.Android)
@@ -42,7 +40,6 @@ val ComposeUiTooling = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "compose-uitooling",
         libraryName = "compose-uitooling",
-        libraryAccessor = "compose.uitooling",
     ),
     applyToModule = true,
     platforms = setOf(ComposePlatform.Android)
@@ -58,7 +55,6 @@ val LibresPlugin = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "libres",
         libraryName = "libres",
-        libraryAccessor = "libres",
     ),
     applyToModule = true,
     platforms = emptySet()
@@ -79,7 +75,6 @@ val Voyager = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "voyager",
         libraryName = "voyager-navigator",
-        libraryAccessor = "voyager.navigator",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -95,7 +90,6 @@ val ImageLoader = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "composeImageLoader",
         libraryName = "composeImageLoader",
-        libraryAccessor = "composeImageLoader",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -111,7 +105,6 @@ val Napier = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "napier",
         libraryName = "napier",
-        libraryAccessor = "napier",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -127,7 +120,6 @@ val KotlinxDateTime = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "kotlinx-datetime",
         libraryName = "kotlinx-datetime",
-        libraryAccessor = "kotlinx.datetime",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -143,7 +135,6 @@ val MultiplatformSettings = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "multiplatformSettings",
         libraryName = "multiplatformSettings",
-        libraryAccessor = "multiplatformSettings",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -159,7 +150,6 @@ val Koin = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "koin",
         libraryName = "koin-core",
-        libraryAccessor = "koin.core",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -175,7 +165,6 @@ val KStore = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "kstore",
         libraryName = "kstore",
-        libraryAccessor = "kstore",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -191,7 +180,6 @@ val KtorCore = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "ktor",
         libraryName = "ktor-core",
-        libraryAccessor = "ktor.core",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -201,7 +189,6 @@ val KtorClientDarwin = KtorCore.copy(
     id = "ktor-client-darwin",
     versionCatalog = KtorCore.versionCatalog.copy(
         libraryName = "ktor-client-darwin",
-        libraryAccessor = "ktor.client.darwin",
     ),
     platforms = setOf(ComposePlatform.Ios)
 )
@@ -210,7 +197,6 @@ val KtorClientOkhttp = KtorCore.copy(
     id = "ktor-client-okhttp",
     versionCatalog = KtorCore.versionCatalog.copy(
         libraryName = "ktor-client-okhttp",
-        libraryAccessor = "ktor.client.okhttp",
     ),
     platforms = setOf(ComposePlatform.Android, ComposePlatform.Desktop)
 )
@@ -219,7 +205,6 @@ val KtorClientJs = KtorCore.copy(
     id = "ktor-client-js",
     versionCatalog = KtorCore.versionCatalog.copy(
         libraryName = "ktor-client-js",
-        libraryAccessor = "ktor.client.js",
     ),
     platforms = setOf(ComposePlatform.Browser)
 )
@@ -234,7 +219,6 @@ val KotlinxCoroutinesCore = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "kotlinx-coroutines",
         libraryName = "kotlinx-coroutines-core",
-        libraryAccessor = "kotlinx.coroutines.core",
     ),
     applyToModule = true,
     platforms = AllPlatforms
@@ -244,7 +228,6 @@ val KotlinxCoroutinesAndroid = KotlinxCoroutinesCore.copy(
     id = "kotlinx-coroutines-android",
     versionCatalog = KotlinxCoroutinesCore.versionCatalog.copy(
         libraryName = "kotlinx-coroutines-android",
-        libraryAccessor = "kotlinx.coroutines.android",
     ),
     platforms = setOf(ComposePlatform.Android)
 )
@@ -259,7 +242,6 @@ val KotlinxSerializationPlugin = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "",
         libraryName = "",
-        libraryAccessor = "",
     ),
     applyToModule = true,
     platforms = emptySet()
@@ -273,7 +255,6 @@ val KotlinxSerializationJson = KotlinxSerializationPlugin.copy(
     versionCatalog = VersionCatalog(
         versionRefName = "kotlinx-serialization",
         libraryName = "kotlinx-serialization-json",
-        libraryAccessor = "kotlinx.serialization.json",
     ),
     platforms = AllPlatforms
 )
@@ -288,7 +269,6 @@ val SQLDelightPlugin = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "sqlDelight",
         libraryName = "sqlDelight",
-        libraryAccessor = "sqlDelight",
     ),
     applyToModule = true,
     platforms = emptySet()
@@ -298,7 +278,6 @@ val SQLDelightDriverJvm = SQLDelightPlugin.copy(
     id = "sqlite-driver",
     versionCatalog = SQLDelightPlugin.versionCatalog.copy(
         libraryName = "sqlDelight-driver-sqlite",
-        libraryAccessor = "sqlDelight.driver.sqlite",
     ),
     platforms = setOf(ComposePlatform.Desktop)
 )
@@ -307,7 +286,6 @@ val SQLDelightDriverAndroid = SQLDelightPlugin.copy(
     id = "android-driver",
     versionCatalog = SQLDelightPlugin.versionCatalog.copy(
         libraryName = "sqlDelight-driver-android",
-        libraryAccessor = "sqlDelight.driver.android",
     ),
     platforms = setOf(ComposePlatform.Android)
 )
@@ -316,7 +294,6 @@ val SQLDelightDriverNative = SQLDelightPlugin.copy(
     id = "native-driver",
     versionCatalog = SQLDelightPlugin.versionCatalog.copy(
         libraryName = "sqlDelight-driver-native",
-        libraryAccessor = "sqlDelight.driver.native",
     ),
     platforms = setOf(ComposePlatform.Ios)
 )
@@ -325,7 +302,6 @@ val SQLDelightDriverJs = SQLDelightPlugin.copy(
     id = "sqljs-driver",
     versionCatalog = SQLDelightPlugin.versionCatalog.copy(
         libraryName = "sqlDelight-driver-sqljs",
-        libraryAccessor = "sqlDelight.driver.sqljs",
     ),
     platforms = setOf(ComposePlatform.Browser)
 )
@@ -340,7 +316,6 @@ val ApolloPlugin = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "apollo",
         libraryName = "apollo",
-        libraryAccessor = "apollo",
     ),
     applyToModule = true,
     platforms = emptySet()
@@ -350,7 +325,6 @@ val ApolloRuntime = ApolloPlugin.copy(
     id = "apollo-runtime",
     versionCatalog = ApolloPlugin.versionCatalog.copy(
         libraryName = "apollo-runtime",
-        libraryAccessor = "apollo.runtime",
     ),
     platforms = AllPlatforms
 )
@@ -365,7 +339,6 @@ val BuildConfigPlugin = Dependency(
     versionCatalog = VersionCatalog(
         versionRefName = "buildConfig",
         libraryName = "buildConfig",
-        libraryAccessor = "buildConfig",
     ),
     applyToModule = true,
     platforms = emptySet()

--- a/src/commonMain/kotlin/wizard/Entity.kt
+++ b/src/commonMain/kotlin/wizard/Entity.kt
@@ -49,7 +49,6 @@ data class Dependency(
 data class VersionCatalog(
     val versionRefName: String,
     val libraryName: String,
-    val libraryAccessor: String,
 )
 
 fun Dependency.isPlugin() = platforms.isEmpty()
@@ -59,6 +58,8 @@ fun Dependency.pluginNotation() = when {
     this == KotlinxSerializationPlugin -> "kotlin(\"plugin.serialization\")"
     else -> "alias(libs.plugins.${versionCatalog.libraryAccessor})"
 }
+
+val VersionCatalog.libraryAccessor: String get() = libraryName.replace("-", ".")
 
 interface ProjectFile {
     val path: String

--- a/src/commonMain/kotlin/wizard/Entity.kt
+++ b/src/commonMain/kotlin/wizard/Entity.kt
@@ -30,6 +30,10 @@ val ProjectInfo.hasBrowser get() = platforms.any { it == ComposePlatform.Browser
 val ProjectInfo.packagePath get() = packageId.replace(".", "/")
 val ProjectInfo.safeName get() = name.replace(" ", "-")
 
+val ProjectInfo.kotlinVersionRef get() = "kotlin"
+val ProjectInfo.agpVersionRef get() = "agp"
+val ProjectInfo.composeVersionRef get() = "compose"
+
 data class Dependency(
     val title: String,
     val description: String,
@@ -37,15 +41,23 @@ data class Dependency(
     val group: String,
     val id: String,
     val version: String,
-    val platforms: Set<ComposePlatform>
+    val versionCatalog: VersionCatalog,
+    val applyToModule: Boolean,
+    val platforms: Set<ComposePlatform>,
+)
+
+data class VersionCatalog(
+    val versionRefName: String,
+    val libraryName: String,
+    val libraryAccessor: String,
 )
 
 fun Dependency.isPlugin() = platforms.isEmpty()
 fun Dependency.isCommon() = platforms == AllPlatforms
-fun Dependency.libraryNotation() = "implementation(\"$group:$id:$version\")"
+fun Dependency.libraryNotation() = "implementation(libs.${versionCatalog.libraryAccessor})"
 fun Dependency.pluginNotation() = when {
     this == KotlinxSerializationPlugin -> "kotlin(\"plugin.serialization\")"
-    else -> "id(\"$group\")"
+    else -> "alias(libs.plugins.${versionCatalog.libraryAccessor})"
 }
 
 interface ProjectFile {

--- a/src/commonMain/kotlin/wizard/files/GradleLibsVersion.kt
+++ b/src/commonMain/kotlin/wizard/files/GradleLibsVersion.kt
@@ -1,0 +1,66 @@
+package wizard.files
+
+import wizard.KotlinxSerializationPlugin
+import wizard.ProjectFile
+import wizard.ProjectInfo
+import wizard.agpVersionRef
+import wizard.composeVersionRef
+import wizard.isPlugin
+import wizard.kotlinVersionRef
+
+class GradleLibsVersion(info: ProjectInfo) : ProjectFile {
+    override val path = "gradle/libs.versions.toml"
+    override val content = buildString {
+        // versions
+        fun versionRef(versionRef: String, version: String) = "$versionRef = \"${version}\""
+        val versions = info.dependencies.distinctBy { it.versionCatalog.versionRefName }
+
+        appendLine("[versions]")
+        appendLine()
+
+        appendLine(versionRef(info.composeVersionRef, info.composeVersion))
+        appendLine(versionRef(info.kotlinVersionRef, info.kotlinVersion))
+        appendLine(versionRef(info.agpVersionRef, info.agpVersion))
+
+        for (dependency in versions) {
+            val config = dependency.versionCatalog
+            if(config.versionRefName.isNotEmpty()) {
+                appendLine(versionRef(config.versionRefName, dependency.version))
+            }
+        }
+
+        // libraries
+        val libraries = info.dependencies.filterNot { it.isPlugin() }
+        appendLine()
+        appendLine("[libraries]")
+        appendLine()
+
+        for (dependency in libraries) {
+            val config = dependency.versionCatalog
+            appendLine("${config.libraryName} = { module = \"${dependency.group}:${dependency.id}\", version.ref = \"${config.versionRefName}\" }")
+        }
+
+        // plugins
+        fun plugin(pluginName: String, id: String, versionRef: String) =
+            "$pluginName = { id = \"${id}\", version.ref = \"${versionRef}\" }"
+        val plugins = info.dependencies
+            .filter { it.isPlugin() }
+            .filterNot { it == KotlinxSerializationPlugin }
+
+        appendLine()
+        appendLine("[plugins]")
+        appendLine()
+
+        appendLine(plugin("compose", "org.jetbrains.compose", info.composeVersionRef))
+        appendLine(plugin("android-application", "com.android.application", info.agpVersionRef))
+        appendLine(plugin("android-library", "com.android.library", info.agpVersionRef))
+
+
+        for (dependency in plugins) {
+            val config = dependency.versionCatalog
+            appendLine(plugin(config.libraryName, dependency.group, config.versionRefName))
+        }
+
+
+    }
+}

--- a/src/commonMain/kotlin/wizard/files/RootBuildGradleKts.kt
+++ b/src/commonMain/kotlin/wizard/files/RootBuildGradleKts.kt
@@ -6,20 +6,20 @@ class RootBuildGradleKts(info: ProjectInfo) : ProjectFile {
     override val path = "build.gradle.kts"
     override val content = buildString {
         appendLine("plugins {")
-        appendLine("        kotlin(\"multiplatform\").version(libs.versions.kotlin.get()).apply(false)")
-        appendLine("        kotlin(\"native.cocoapods\").version(libs.versions.kotlin.get()).apply(false)")
+        appendLine("    kotlin(\"multiplatform\").version(libs.versions.kotlin.get()).apply(false)")
+        appendLine("    kotlin(\"native.cocoapods\").version(libs.versions.kotlin.get()).apply(false)")
         if(info.hasAndroid) {
-            appendLine("        kotlin(\"android\").version(libs.versions.kotlin.get()).apply(false)")
-            appendLine("        alias(libs.plugins.android.application).apply(false)")
-            appendLine("        alias(libs.plugins.android.library).apply(false)")
+            appendLine("    kotlin(\"android\").version(libs.versions.kotlin.get()).apply(false)")
+            appendLine("    alias(libs.plugins.android.application).apply(false)")
+            appendLine("    alias(libs.plugins.android.library).apply(false)")
         }
-        appendLine("        alias(libs.plugins.compose).apply(false)")
+        appendLine("    alias(libs.plugins.compose).apply(false)")
 
         info.dependencies.filter { it.isPlugin() }.forEach { dep ->
             if (dep == KotlinxSerializationPlugin) {
-                appendLine("        ${dep.pluginNotation()}.version(libs.versions.kotlin.get()).apply(false)")
+                appendLine("    ${dep.pluginNotation()}.version(libs.versions.kotlin.get()).apply(false)")
             } else {
-                appendLine("        alias(libs.plugins.${dep.versionCatalog.libraryAccessor}).apply(false)")
+                appendLine("    alias(libs.plugins.${dep.versionCatalog.libraryAccessor}).apply(false)")
             }
         }
 

--- a/src/commonMain/kotlin/wizard/files/RootBuildGradleKts.kt
+++ b/src/commonMain/kotlin/wizard/files/RootBuildGradleKts.kt
@@ -6,13 +6,21 @@ class RootBuildGradleKts(info: ProjectInfo) : ProjectFile {
     override val path = "build.gradle.kts"
     override val content = buildString {
         appendLine("plugins {")
-        appendLine("    kotlin(\"multiplatform\").apply(false)")
-        if (info.hasAndroid) {
-            appendLine("    id(\"com.android.application\").apply(false)")
+        appendLine("        kotlin(\"multiplatform\").version(libs.versions.kotlin.get()).apply(false)")
+        appendLine("        kotlin(\"native.cocoapods\").version(libs.versions.kotlin.get()).apply(false)")
+        if(info.hasAndroid) {
+            appendLine("        kotlin(\"android\").version(libs.versions.kotlin.get()).apply(false)")
+            appendLine("        alias(libs.plugins.android.application).apply(false)")
+            appendLine("        alias(libs.plugins.android.library).apply(false)")
         }
+        appendLine("        alias(libs.plugins.compose).apply(false)")
 
         info.dependencies.filter { it.isPlugin() }.forEach { dep ->
-            appendLine("    ${dep.pluginNotation()}.apply(false)")
+            if (dep == KotlinxSerializationPlugin) {
+                appendLine("        ${dep.pluginNotation()}.version(libs.versions.kotlin.get()).apply(false)")
+            } else {
+                appendLine("        alias(libs.plugins.${dep.versionCatalog.libraryAccessor}).apply(false)")
+            }
         }
 
         appendLine("}")

--- a/src/commonMain/kotlin/wizard/files/SettingsGradleKts.kt
+++ b/src/commonMain/kotlin/wizard/files/SettingsGradleKts.kt
@@ -15,25 +15,6 @@ class SettingsGradleKts(info: ProjectInfo) : ProjectFile {
         appendLine("        mavenCentral()")
         appendLine("        maven(\"https://maven.pkg.jetbrains.space/public/p/compose/dev\")")
         appendLine("    }")
-        appendLine("    plugins {")
-        appendLine("        val kotlin = \"${info.kotlinVersion}\"")
-        appendLine("        kotlin(\"android\").version(kotlin)")
-        appendLine("        kotlin(\"multiplatform\").version(kotlin)")
-        appendLine("        kotlin(\"native.cocoapods\").version(kotlin)")
-        appendLine("")
-        appendLine("        id(\"com.android.application\").version(\"${info.agpVersion}\")")
-        appendLine("        id(\"org.jetbrains.compose\").version(\"${info.composeVersion}\")")
-
-        info.dependencies.filter { it.isPlugin() }.forEach { dep ->
-            if (dep == KotlinxSerializationPlugin) {
-                appendLine("        ${dep.pluginNotation()}.version(kotlin)")
-            } else {
-                appendLine("        ${dep.pluginNotation()}.version(\"${dep.version}\")")
-            }
-        }
-
-        appendLine("")
-        appendLine("    }")
         appendLine("}")
         appendLine("")
         appendLine("dependencyResolutionManagement {")

--- a/src/commonMain/kotlin/wizard/files/app/ModuleBuildGradleKts.kt
+++ b/src/commonMain/kotlin/wizard/files/app/ModuleBuildGradleKts.kt
@@ -8,13 +8,14 @@ class ModuleBuildGradleKts(info: ProjectInfo) : ProjectFile {
         val plugins = mutableSetOf<Dependency>()
         val commonDeps = mutableSetOf<Dependency>()
         val otherDeps = mutableSetOf<Dependency>()
-        info.dependencies.forEach { dep ->
-            when  {
-                dep.isPlugin() -> plugins.add(dep)
-                dep.isCommon() -> commonDeps.add(dep)
-                else -> otherDeps.add(dep)
+        info.dependencies.filter { it.applyToModule }
+            .forEach { dep ->
+                when  {
+                    dep.isPlugin() -> plugins.add(dep)
+                    dep.isCommon() -> commonDeps.add(dep)
+                    else -> otherDeps.add(dep)
+                }
             }
-        }
 
 
         if (info.hasDesktop) {
@@ -23,12 +24,12 @@ class ModuleBuildGradleKts(info: ProjectInfo) : ProjectFile {
         }
         appendLine("plugins {")
         appendLine("    kotlin(\"multiplatform\")")
-        appendLine("    id(\"org.jetbrains.compose\")")
+        appendLine("    alias(libs.plugins.compose)")
         if (info.hasIos) {
             appendLine("    kotlin(\"native.cocoapods\")")
         }
         if (info.hasAndroid) {
-            appendLine("    id(\"com.android.application\")")
+            appendLine("    alias(libs.plugins.android.application)")
         }
         plugins.forEach { dep ->
             appendLine("    ${dep.pluginNotation()}")

--- a/src/commonMain/kotlin/wizard/generator.kt
+++ b/src/commonMain/kotlin/wizard/generator.kt
@@ -11,6 +11,7 @@ fun ProjectInfo.buildFiles() = buildList {
     add(Gradlew())
     add(GradleWrapperProperties(this@buildFiles))
     add(GradleWrapperJar())
+    add(GradleLibsVersion(this@buildFiles))
 
     add(GradleProperties())
     add(RootBuildGradleKts(this@buildFiles))

--- a/src/jvmTest/kotlin/wizard/GeneratorTest.kt
+++ b/src/jvmTest/kotlin/wizard/GeneratorTest.kt
@@ -1,5 +1,6 @@
 package wizard
 
+import wizard.files.GradleLibsVersion
 import wizard.files.app.ModuleBuildGradleKts
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,6 +20,7 @@ class GeneratorTest {
             gradlew
             gradle/wrapper/gradle-wrapper.properties
             gradle/wrapper/gradle-wrapper.jar
+            gradle/libs.versions.toml
             gradle.properties
             build.gradle.kts
             settings.gradle.kts
@@ -55,9 +57,9 @@ class GeneratorTest {
 
                 plugins {
                     kotlin("multiplatform")
-                    id("org.jetbrains.compose")
+                    alias(libs.plugins.compose)
                     kotlin("native.cocoapods")
-                    id("com.android.application")
+                    alias(libs.plugins.android.application)
                 }
 
                 kotlin {
@@ -109,9 +111,9 @@ class GeneratorTest {
 
                         val androidMain by getting {
                             dependencies {
-                                implementation("androidx.appcompat:appcompat:1.6.1")
-                                implementation("androidx.activity:activity-compose:1.7.0")
-                                implementation("androidx.compose.ui:ui-tooling:1.4.0")
+                                implementation(libs.androidx.appcompat)
+                                implementation(libs.androidx.activityCompose)
+                                implementation(libs.compose.uitooling)
                             }
                         }
 
@@ -214,6 +216,7 @@ class GeneratorTest {
             gradlew
             gradle/wrapper/gradle-wrapper.properties
             gradle/wrapper/gradle-wrapper.jar
+            gradle/libs.versions.toml
             gradle.properties
             build.gradle.kts
             settings.gradle.kts
@@ -231,8 +234,8 @@ class GeneratorTest {
             """
                 plugins {
                     kotlin("multiplatform")
-                    id("org.jetbrains.compose")
-                    id("com.android.application")
+                    alias(libs.plugins.compose)
+                    alias(libs.plugins.android.application)
                 }
 
                 kotlin {
@@ -261,9 +264,9 @@ class GeneratorTest {
 
                         val androidMain by getting {
                             dependencies {
-                                implementation("androidx.appcompat:appcompat:1.6.1")
-                                implementation("androidx.activity:activity-compose:1.7.0")
-                                implementation("androidx.compose.ui:ui-tooling:1.4.0")
+                                implementation(libs.androidx.appcompat)
+                                implementation(libs.androidx.activityCompose)
+                                implementation(libs.compose.uitooling)
                             }
                         }
 
@@ -317,6 +320,7 @@ class GeneratorTest {
             gradlew
             gradle/wrapper/gradle-wrapper.properties
             gradle/wrapper/gradle-wrapper.jar
+            gradle/libs.versions.toml
             gradle.properties
             build.gradle.kts
             settings.gradle.kts
@@ -343,7 +347,7 @@ class GeneratorTest {
             """
                 plugins {
                     kotlin("multiplatform")
-                    id("org.jetbrains.compose")
+                    alias(libs.plugins.compose)
                     kotlin("native.cocoapods")
                 }
 
@@ -425,6 +429,7 @@ class GeneratorTest {
             gradlew
             gradle/wrapper/gradle-wrapper.properties
             gradle/wrapper/gradle-wrapper.jar
+            gradle/libs.versions.toml
             gradle.properties
             build.gradle.kts
             settings.gradle.kts
@@ -444,7 +449,7 @@ class GeneratorTest {
 
                 plugins {
                     kotlin("multiplatform")
-                    id("org.jetbrains.compose")
+                    alias(libs.plugins.compose)
                 }
 
                 kotlin {
@@ -508,6 +513,7 @@ class GeneratorTest {
             gradlew
             gradle/wrapper/gradle-wrapper.properties
             gradle/wrapper/gradle-wrapper.jar
+            gradle/libs.versions.toml
             gradle.properties
             build.gradle.kts
             settings.gradle.kts
@@ -527,7 +533,7 @@ class GeneratorTest {
             """
                 plugins {
                     kotlin("multiplatform")
-                    id("org.jetbrains.compose")
+                    alias(libs.plugins.compose)
                 }
 
                 kotlin {


### PR DESCRIPTION
This PRs generate a `libs.versions.toml` and move all dependencies to it, also refactor the code to use libraries from it as well as using Kotlin version in the plugins from the version reference in the catalog.

Reason and benefits of this change:
- Android community is moving towards using Version Catalog in TOML format. Google app sample is using it, Android Studio latest version can create a version catalog and move a dependency from `build.gradle.kts` to version catalog.
- This will make possible to have library dependencies available in the version catalog but not applied to the project, to easily extend the functionality. An example would be Voyager Animations, BottomSheet artifacts, would be nice to have on Version Catalog but not applied by default in the composeApp module.
- This will help scalability of the project, modularization, etc.

Examples of output:

Module build script example
```kotlin
plugins {
    kotlin("multiplatform")
    alias(libs.plugins.compose)
    kotlin("native.cocoapods")
    alias(libs.plugins.android.application)
    alias(libs.plugins.libres)
    alias(libs.plugins.buildConfig)
}

val commonMain by getting {
    dependencies {
        implementation(compose.runtime)
        implementation(compose.foundation)
        implementation(compose.material)
        implementation(libs.napier)
        implementation(libs.libres)
        implementation(libs.voyager.navigator)
        implementation(libs.composeImageLoader)
        implementation(libs.kotlinx.coroutines.core)
        implementation(libs.multiplatformSettings)
        implementation(libs.koin.core)
        implementation(libs.kstore)
    }
}

val androidMain by getting {
    dependencies {
        implementation(libs.androidx.appcompat)
        implementation(libs.androidx.activityCompose)
        implementation(libs.compose.uitooling)
        implementation(libs.kotlinx.coroutines.android)
    }
}
```

Root build script example
```kotlin
plugins {
    kotlin("multiplatform").version(libs.versions.kotlin.get()).apply(false)
    kotlin("native.cocoapods").version(libs.versions.kotlin.get()).apply(false)
    kotlin("android").version(libs.versions.kotlin.get()).apply(false)
    alias(libs.plugins.android.application).apply(false)
    alias(libs.plugins.android.library).apply(false)
    alias(libs.plugins.compose).apply(false)
    alias(libs.plugins.libres).apply(false)
    alias(libs.plugins.buildConfig).apply(false)
}
```

Version catalog example
```toml
[versions]

compose = "1.4.0-alpha01-dev1004"
kotlin = "1.8.10"
agp = "7.4.2"
androidx-appcompat = "1.6.1"
androidx-activityCompose = "1.7.0"
compose-uitooling = "1.4.0"
napier = "2.6.1"
libres = "1.1.7"
voyager = "1.0.0-rc04"
composeImageLoader = "1.2.10"
kotlinx-coroutines = "1.6.4"
buildConfig = "3.1.0"
multiplatformSettings = "1.0.0"
koin = "3.4.0"
kstore = "0.5.0"

[libraries]

androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
compose-uitooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-uitooling" }
napier = { module = "io.github.aakira:napier", version.ref = "napier" }
libres = { module = "io.github.skeptick.libres:libres-compose", version.ref = "libres" }
voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
composeImageLoader = { module = "io.github.qdsfdhvh:image-loader", version.ref = "composeImageLoader" }
kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
multiplatformSettings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
kstore = { module = "io.github.xxfast:kstore", version.ref = "kstore" }

[plugins]

compose = { id = "org.jetbrains.compose", version.ref = "compose" }
android-application = { id = "com.android.application", version.ref = "agp" }
android-library = { id = "com.android.library", version.ref = "agp" }
libres = { id = "io.github.skeptick.libres", version.ref = "libres" }
buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig" }
```
