### PR TITLE
Add support for Kermit

### DIFF
--- a/src/commonMain/kotlin/wizard/Dependencies.kt
+++ b/src/commonMain/kotlin/wizard/Dependencies.kt
@@ -77,6 +77,18 @@ val ImageLoader = Dependency(
     platforms = AllPlatforms
 )
 
+val Kermit = Dependency(
+    title = "Kermit",
+    description = "Kermit by Touchlab is a Kotlin Multiplatform centralized logging utility.",
+    url = "https://github.com/touchlab/Kermit",
+    group = "co.touchlab",
+    id = "kermit",
+    version = "2.0.0-RC4",
+    catalogVersionName = "kermit",
+    catalogName = "kermit",
+    platforms = AllPlatforms
+)
+
 val Napier = Dependency(
     title = "Napier",
     description = "Napier is a logger library for Kotlin Multiplatform.",

--- a/src/jsMain/kotlin/ui/Content.kt
+++ b/src/jsMain/kotlin/ui/Content.kt
@@ -104,6 +104,7 @@ val Content = FC<AppProps> { props ->
                     }
 
                     val deps = mapOf(
+                        Kermit to useState(true),
                         Napier to useState(true),
                         LibresCompose to useState(true),
                         Voyager to useState(true),

--- a/src/jvmTest/kotlin/wizard/GeneratedProjectTest.kt
+++ b/src/jvmTest/kotlin/wizard/GeneratedProjectTest.kt
@@ -21,6 +21,7 @@ internal val allDependencies = setOf(
     LibresCompose,
     Voyager,
     ImageLoader,
+    Kermit,
     Napier,
     KotlinxDateTime,
     MultiplatformSettings,
@@ -83,6 +84,7 @@ class GeneratedProjectTest {
                     LibresCompose,
                     Voyager,
                     ImageLoader,
+                    Kermit,
                     Napier,
                     KotlinxDateTime,
                     MultiplatformSettings,
@@ -109,6 +111,7 @@ class GeneratedProjectTest {
                 name = "test js compose app",
                 platforms = setOf(ComposePlatform.Browser),
                 dependencies = setOf(
+                    Kermit,
                     Napier,
                     KotlinxDateTime,
                     MultiplatformSettings,

--- a/src/jvmTest/kotlin/wizard/GeneratorTest.kt
+++ b/src/jvmTest/kotlin/wizard/GeneratorTest.kt
@@ -113,6 +113,7 @@ class GeneratorTest {
                                 implementation(libs.libres)
                                 implementation(libs.voyager.navigator)
                                 implementation(libs.composeImageLoader)
+                                implementation(libs.kermit)
                                 implementation(libs.napier)
                                 implementation(libs.kotlinx.datetime)
                                 implementation(libs.multiplatformSettings)
@@ -274,6 +275,7 @@ class GeneratorTest {
                 libres = "${LibresCompose.version}"
                 voyager = "${Voyager.version}"
                 composeImageLoader = "${ImageLoader.version}"
+                kermit = "${Kermit.version}"
                 napier = "${Napier.version}"
                 kotlinx-datetime = "${KotlinxDateTime.version}"
                 multiplatformSettings = "${MultiplatformSettings.version}"
@@ -295,6 +297,7 @@ class GeneratorTest {
                 libres = { module = "io.github.skeptick.libres:libres-compose", version.ref = "libres" }
                 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
                 composeImageLoader = { module = "io.github.qdsfdhvh:image-loader", version.ref = "composeImageLoader" }
+                kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
                 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
                 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
                 multiplatformSettings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }


### PR DESCRIPTION
Added support for `Kermit` logging library for Kotlin Multiplatform

#### Testing
`./gradlew check` - passed locally