### PR TITLE
Update BrowserViewportWindowKt.kt

### DIFF
--- a/src/commonMain/kotlin/wizard/files/app/BrowserViewportWindowKt.kt
+++ b/src/commonMain/kotlin/wizard/files/app/BrowserViewportWindowKt.kt
@@ -10,78 +10,129 @@ class BrowserViewportWindowKt  : ProjectFile {
             "INVISIBLE_REFERENCE",
             "EXPOSED_PARAMETER_TYPE"
         ) // WORKAROUND: ComposeWindow and ComposeLayer are internal
-
+        
         import androidx.compose.runtime.Composable
+        import androidx.compose.ui.createSkiaLayer
+        import androidx.compose.ui.native.ComposeLayer
+        import androidx.compose.ui.platform.JSTextInputService
+        import androidx.compose.ui.unit.Density
         import androidx.compose.ui.window.ComposeWindow
         import kotlinx.browser.document
         import kotlinx.browser.window
         import org.w3c.dom.HTMLCanvasElement
         import org.w3c.dom.HTMLStyleElement
         import org.w3c.dom.HTMLTitleElement
-
-        private const val CANVAS_ELEMENT_ID = "ComposeTarget" // Hardwired into ComposeWindow
-
+        
         /**
          * A Skiko/Canvas-based top-level window using the browser's entire viewport. Supports resizing.
          * Author: https://github.com/OliverO2
-         * Source: https://github.com/OliverO2/compose-counting-grid/blob/eb79f7c8be7804d4323114be30ce498cfac6d2b0/src/frontendWebMain/kotlin/BrowserViewportWindow.kt
+         * Source: https://github.com/OliverO2/compose-counting-grid/blob/master/src/frontendJsMain/kotlin/BrowserViewportWindow.kt
          */
         @Suppress("FunctionName")
         fun BrowserViewportWindow(
             title: String = "Untitled",
-            content: @Composable ComposeWindow.() -> Unit
+            content: @Composable () -> Unit,
         ) {
-            val htmlHeadElement = document.head!!
-            htmlHeadElement.appendChild(
-                (document.createElement("style") as HTMLStyleElement).apply {
-                    type = "text/css"
-                    appendChild(
-                        document.createTextNode(
-                            ""${'"'}
-                            html, body {
-                                overflow: hidden;
-                                margin: 0 !important;
-                                padding: 0 !important;
-                            }
-
-                            #${'$'}CANVAS_ELEMENT_ID {
-                                outline: none;
-                            }
-                            ""${'"'}.trimIndent()
-                        )
-                    )
+            AutoSizingComposeWindow(title).apply {
+                setContent {
+                    content()
                 }
+            }
+        }
+        
+        private const val CANVAS_ELEMENT_ID = "ComposeTarget"
+        
+        private class AutoSizingComposeWindow(title: String) {
+        
+            private val density: Density = Density(
+                density = window.devicePixelRatio.toFloat(),
+                fontScale = 1f
             )
-
-            fun HTMLCanvasElement.fillViewportSize() {
-                setAttribute("width", "${'$'}{window.innerWidth}")
-                setAttribute("height", "${'$'}{window.innerHeight}")
+        
+            private val jsTextInputService = JSTextInputService()
+            val platform = ComposeWindow().platform
+            private val layer = ComposeLayer(
+                layer = createSkiaLayer(),
+                platform = platform,
+                input = jsTextInputService.input
+            )
+        
+            var canvas = document.getElementById(CANVAS_ELEMENT_ID) as HTMLCanvasElement
+        
+            private val htmlHeadElement = document.head!!
+        
+            private fun resizeCanvasToViewport() {
+                val scale = layer.layer.contentScale
+                val density = window.devicePixelRatio.toFloat()
+        
+                // Cloning the canvas node to work around multiple event listeners being applied by
+                // SkiaLayer.attachTo() on every resize event.
+                // See https://github.com/JetBrains/compose-multiplatform-core/pull/692/files
+                val oldCanvas = canvas
+                canvas = oldCanvas.cloneNode(true) as HTMLCanvasElement
+                oldCanvas.parentElement!!.replaceChild(canvas, oldCanvas)
+        
+                canvas.width = window.innerWidth
+                canvas.height = window.innerHeight
+                canvas.tabIndex = 0
+                layer.layer.attachTo(canvas)
+                layer.layer.needRedraw()
+                layer.setSize(
+                    (canvas.width / scale * density).toInt(),
+                    (canvas.height / scale * density).toInt()
+                )
             }
-
-            val canvas = (document.getElementById(CANVAS_ELEMENT_ID) as HTMLCanvasElement).apply {
-                fillViewportSize()
-            }
-
-            ComposeWindow().apply {
-                window.addEventListener("resize", {
-                    val scale = layer.layer.contentScale
-                    val density = window.devicePixelRatio.toFloat()
-                    canvas.fillViewportSize()
-                    layer.layer.attachTo(canvas)
-                    layer.layer.needRedraw()
-                    layer.setSize((canvas.width / scale * density).toInt(), (canvas.height / scale * density).toInt())
-                })
-
-                // WORKAROUND: ComposeWindow does not implement `setTitle(title)`
+        
+            init {
+                htmlHeadElement.appendChild(
+                    (document.createElement("style") as HTMLStyleElement).apply {
+                        type = "text/css"
+                        appendChild(
+                            document.createTextNode(
+                                """
+                                html, body {
+                                    overflow: hidden;
+                                    margin: 0 !important;
+                                    padding: 0 !important;
+                                }
+            
+                                #$CANVAS_ELEMENT_ID {
+                                    outline: none;
+                                }
+                                """.trimIndent()
+                            )
+                        )
+                    }
+                )
+        
+                resizeCanvasToViewport()
+        
+                window.addEventListener("resize", { resizeCanvasToViewport() })
+        
                 val htmlTitleElement = (
                         htmlHeadElement.getElementsByTagName("title").item(0)
                             ?: document.createElement("title").also { htmlHeadElement.appendChild(it) }
                         ) as HTMLTitleElement
                 htmlTitleElement.textContent = title
-
-                setContent {
-                    content(this)
-                }
+            }
+        
+            /**
+             * Sets Compose content of the ComposeWindow.
+             *
+             * @param content Composable content of the ComposeWindow.
+             */
+            fun setContent(
+                content: @Composable () -> Unit,
+            ) {
+                layer.setDensity(density)
+                layer.setContent(
+                    content = content
+                )
+            }
+        
+            // TODO: need to call .dispose() on window close.
+            fun dispose() {
+                layer.dispose()
             }
         }
 


### PR DESCRIPTION
This PR forks the latest logic from OliverO2's [repository](https://github.com/OliverO2/compose-counting-grid/blob/master/src/frontendJsMain/kotlin/BrowserViewportWindow.kt) that supports Kotlin 1.9.0 and above as the existing logic does not work for Kotlin 1.9.0 and above anymore.