### PR TITLE
Adding task(testClasses) to module gradle file to prevent rebuild issue

### DIFF
--- a/src/commonMain/kotlin/wizard/files/composeApp/ModuleBuildGradleKts.kt
+++ b/src/commonMain/kotlin/wizard/files/composeApp/ModuleBuildGradleKts.kt
@@ -50,6 +50,7 @@ class ModuleBuildGradleKts(info: ProjectInfo) : ProjectFile {
         appendLine("}")
         appendLine("")
         appendLine("kotlin {")
+        appendLine("    task(\"testClasses\")")
         if (info.hasPlatform(ProjectPlatform.Android)) {
             appendLine("    androidTarget {")
             appendLine("        compilations.all {")

--- a/src/commonMain/kotlin/wizard/files/kmpLibrary/ModuleBuildGradleKts.kt
+++ b/src/commonMain/kotlin/wizard/files/kmpLibrary/ModuleBuildGradleKts.kt
@@ -28,6 +28,7 @@ class ModuleBuildGradleKts(info: ProjectInfo) : ProjectFile {
         appendLine("version = \"1.0\"")
         appendLine("")
         appendLine("kotlin {")
+        appendLine("    task(\"testClasses\")")
         if (info.hasPlatform(ProjectPlatform.Android)) {
             appendLine("    androidTarget {")
             appendLine("        publishLibraryVariants(\"release\")")

--- a/src/jvmTest/kotlin/wizard/ComposeAppGeneratorTest.kt
+++ b/src/jvmTest/kotlin/wizard/ComposeAppGeneratorTest.kt
@@ -93,6 +93,7 @@ class ComposeAppGeneratorTest {
                 }
 
                 kotlin {
+                    task("testClasses")
                     androidTarget {
                         compilations.all {
                             compileTaskProvider {
@@ -405,6 +406,7 @@ class ComposeAppGeneratorTest {
                 }
 
                 kotlin {
+                    task("testClasses")
                     androidTarget {
                         compilations.all {
                             compileTaskProvider {
@@ -543,6 +545,7 @@ class ComposeAppGeneratorTest {
                 }
 
                 kotlin {
+                    task("testClasses")
                     listOf(
                         iosX64(),
                         iosArm64(),
@@ -629,6 +632,7 @@ class ComposeAppGeneratorTest {
                 }
 
                 kotlin {
+                    task("testClasses")
                     jvm()
 
                     sourceSets {
@@ -719,6 +723,7 @@ class ComposeAppGeneratorTest {
                 }
 
                 kotlin {
+                    task("testClasses")
                     js {
                         browser()
                         binaries.executable()
@@ -800,6 +805,7 @@ class ComposeAppGeneratorTest {
                 }
 
                 kotlin {
+                    task("testClasses")
                     wasmJs {
                         browser()
                         binaries.executable()

--- a/src/jvmTest/kotlin/wizard/KmpLibraryGeneratorTest.kt
+++ b/src/jvmTest/kotlin/wizard/KmpLibraryGeneratorTest.kt
@@ -56,6 +56,7 @@ class GeneratorTest {
                 version = "1.0"
 
                 kotlin {
+                    task("testClasses")
                     androidTarget {
                         publishLibraryVariants("release")
                         compilations.all {
@@ -368,6 +369,7 @@ class GeneratorTest {
                 version = "1.0"
 
                 kotlin {
+                    task("testClasses")
                     jvm()
 
                     sourceSets {
@@ -429,6 +431,7 @@ class GeneratorTest {
                 version = "1.0"
                 
                 kotlin {
+                    task("testClasses")
                     androidTarget {
                         publishLibraryVariants("release")
                         compilations.all {


### PR DESCRIPTION
This fixes issue of _"Task 'testClasses' not found in project"_ when rebuilding the project in Android Studio. 

`task("testClasses")` is added to module gradle file.

Related StackOverflow solution: https://stackoverflow.com/questions/36465824/android-studio-task-testclasses-not-found-in-project/78017056#78017056